### PR TITLE
AA Simulation & Testing Harness MVP

### DIFF
--- a/cmd/aasim/block_feeder.go
+++ b/cmd/aasim/block_feeder.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"time"
+
+	"github.com/ledgerwatch/turbo-geth/common"
+	"github.com/ledgerwatch/turbo-geth/consensus/ethash"
+	"github.com/ledgerwatch/turbo-geth/core"
+	"github.com/ledgerwatch/turbo-geth/core/forkid"
+	"github.com/ledgerwatch/turbo-geth/core/types"
+	"github.com/ledgerwatch/turbo-geth/core/vm"
+	"github.com/ledgerwatch/turbo-geth/crypto"
+	"github.com/ledgerwatch/turbo-geth/ethdb"
+	"github.com/ledgerwatch/turbo-geth/log"
+)
+
+type BlockFeeder interface {
+	Head() *types.Block
+	TotalDifficulty() *big.Int
+	ForkID() forkid.ID
+	Genesis() *types.Block
+
+	GetHeaderByHash(hash common.Hash) *types.Header
+	GetHeaderByNumber(number uint64) *types.Header
+	GetBlockByHash(hash common.Hash) (*types.Block, error)
+	GetBlockByNumber(number uint64) (*types.Block, error)
+	GetTotalDifficultyByNumber(number uint64) *big.Int
+}
+
+type BlockGenerator struct {
+	// input               *os.File
+	genesis         *types.Block
+	coinbaseKey     *ecdsa.PrivateKey
+	blocks          []*types.Block
+	blockByHash     map[common.Hash]*types.Block
+	blockByNumber   map[uint64]*types.Block
+	headersByHash   map[common.Hash]*types.Header
+	headersByNumber map[uint64]*types.Header
+	tdByNumber      map[uint64]*big.Int
+	head            *types.Block
+	totalDifficulty *big.Int
+	forkId          forkid.ID
+}
+
+func (bg *BlockGenerator) GetHeaderByHash(hash common.Hash) *types.Header {
+	return bg.headersByHash[hash]
+}
+
+func (bg *BlockGenerator) Genesis() *types.Block {
+	return bg.genesis
+}
+
+func (bg *BlockGenerator) GetHeaderByNumber(number uint64) *types.Header {
+	return bg.headersByNumber[number]
+}
+
+func (bg *BlockGenerator) GetTdByNumber(number uint64) *big.Int {
+	return bg.tdByNumber[number]
+}
+
+func (bg *BlockGenerator) GetBlockByHash(hash common.Hash) (*types.Block, error) {
+	if block, ok := bg.blockByHash[hash]; ok {
+		return block, nil
+	}
+
+	return nil, nil
+}
+
+func (bg *BlockGenerator) GetBlockByNumber(number uint64) (*types.Block, error) {
+	if uint64(len(bg.blocks)) >= number {
+		return nil, fmt.Errorf("Invalid block number")
+	}
+
+	return bg.blocks[number], nil
+}
+func (bg *BlockGenerator) GetTotalDifficultyByNumber(number uint64) *big.Int {
+	return bg.tdByNumber[number]
+}
+
+func (bg *BlockGenerator) TotalDifficulty() *big.Int {
+	return bg.totalDifficulty
+}
+
+func (bg *BlockGenerator) Head() *types.Block {
+	return bg.head
+}
+
+func (bg *BlockGenerator) ForkID() forkid.ID {
+	return bg.forkId
+}
+
+func NewBlockGenerator(ctx context.Context, initialHeight int) (*BlockGenerator, error) {
+	r := rand.New(rand.NewSource(4589489854))
+	db, genesis, extra, engine := ethdb.NewMemDatabase(), genesis(), []byte("BlockGenerator"), ethash.NewFullFaker()
+	genesisBlock := genesis.MustCommit(db)
+
+	coinbaseKey, err2 := crypto.HexToECDSA("ad0f3019b6b8634c080b574f3d8a47ef975f0e4b9f63e82893e9a7bb59c2d609")
+	if err2 != nil {
+		return nil, err2
+	}
+
+	coinbase := crypto.PubkeyToAddress(coinbaseKey.PublicKey)
+
+	blockGen := func(i int, gen *core.BlockGen) {
+		makeGenBlock(db, genesis, extra, coinbaseKey, false, 0, 0, r)(coinbase, i, gen)
+	}
+
+	parent := genesisBlock
+	blocks, _ := core.GenerateChain(ctx, genesis.Config, parent, engine, db, 10, blockGen)
+
+	bg := &BlockGenerator{
+		genesis:         genesisBlock,
+		coinbaseKey:     coinbaseKey,
+		blockByHash:     make(map[common.Hash]*types.Block),
+		blockByNumber:   make(map[uint64]*types.Block),
+		headersByHash:   make(map[common.Hash]*types.Header),
+		headersByNumber: make(map[uint64]*types.Header),
+		tdByNumber:      make(map[uint64]*big.Int),
+	}
+
+	bg.headersByHash[genesisBlock.Header().Hash()] = genesisBlock.Header()
+	bg.headersByNumber[0] = genesisBlock.Header()
+
+	///
+	td := new(big.Int)
+	for _, block := range blocks {
+		log.Info("Saving block", "number", block.Number(), "hash", block.Hash(), "difficulty", block.Difficulty(), "age", common.PrettyAge(time.Unix(int64(block.Time()), 0)))
+
+		header := block.Header()
+		hash := header.Hash()
+		bg.headersByHash[hash] = header
+		bg.headersByNumber[block.NumberU64()] = header
+		bg.blockByHash[hash] = block
+		bg.blockByNumber[block.NumberU64()] = block
+		td = new(big.Int).Add(td, block.Difficulty())
+		bg.tdByNumber[block.NumberU64()] = td
+		parent = block
+	}
+
+	bg.head = parent
+	bg.totalDifficulty = td
+	////
+
+	blockchain, err := core.NewBlockChain(db, nil, genesis.Config, ethash.NewFullFaker(), vm.Config{}, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	bg.forkId = forkid.NewID(blockchain)
+
+	return bg, nil
+}
+
+func makeGenBlock(db ethdb.Database,
+	genesis *core.Genesis,
+	extra []byte,
+	coinbaseKey *ecdsa.PrivateKey,
+	isFork bool,
+	forkBase, forkHeight uint64,
+	r *rand.Rand,
+) func(coinbase common.Address, i int, gen *core.BlockGen) {
+	return func(coinbase common.Address, i int, gen *core.BlockGen) {
+		gen.SetExtra(extra)
+	}
+}

--- a/cmd/aasim/genesis.go
+++ b/cmd/aasim/genesis.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"math/big"
+
+	"github.com/ledgerwatch/turbo-geth/common"
+	"github.com/ledgerwatch/turbo-geth/core"
+)
+
+func genesis() *core.Genesis {
+	genesis := core.DefaultGenesisBlock()
+
+	genesis.Config.HomesteadBlock = big.NewInt(0)
+	genesis.Config.DAOForkBlock = nil
+	genesis.Config.DAOForkSupport = true
+	genesis.Config.EIP150Block = big.NewInt(0)
+	genesis.Config.EIP150Hash = common.HexToHash("0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d")
+	genesis.Config.EIP155Block = big.NewInt(10)
+	genesis.Config.EIP158Block = big.NewInt(10)
+	genesis.Config.ByzantiumBlock = big.NewInt(17)
+	genesis.Config.ConstantinopleBlock = big.NewInt(18)
+	genesis.Config.PetersburgBlock = big.NewInt(19)
+	genesis.Config.IstanbulBlock = big.NewInt(20)
+	genesis.Config.MuirGlacierBlock = big.NewInt(21)
+
+	return genesis
+}

--- a/cmd/aasim/main.go
+++ b/cmd/aasim/main.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/ledgerwatch/turbo-geth/cmd/utils"
+	"github.com/ledgerwatch/turbo-geth/eth"
+	"github.com/ledgerwatch/turbo-geth/log"
+	"github.com/mattn/go-colorable"
+	"github.com/mattn/go-isatty"
+	"github.com/urfave/cli"
+)
+
+var (
+	app = utils.NewApp("", "", "aa simulator")
+)
+
+func init() {
+	app.Action = simulator
+
+	app.Before = func(ctx *cli.Context) error {
+		setupLogger(ctx)
+		return nil
+	}
+
+	app.Flags = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "debug",
+			Usage: "test p2p connection with host",
+		},
+	}
+}
+
+func main() {
+	err := app.Run(os.Args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func simulator(c *cli.Context) error {
+	log.Info("Beginning simulator . . .")
+
+	// set program to shut down on SIGTERM interrupt
+	ctx := getRootContext()
+
+	if c.Bool("debug") {
+		runDebug(c, ctx)
+	}
+
+	return nil
+}
+
+func runDebug(c *cli.Context, ctx context.Context) error {
+	// get local enode address from file
+	nodeToConnect, err := getTargetAddr()
+	if err != nil {
+		return err
+	}
+
+	server := makeP2PServer(ctx, NewSimulatorProtocol(), []string{eth.DebugName})
+
+	err = server.Start()
+	if err != nil {
+		panic(fmt.Errorf("could not start server: %w", err))
+	}
+
+	server.AddPeer(nodeToConnect)
+	time.Sleep(2 * time.Second)
+	server.Stop()
+
+	return nil
+}
+
+func getRootContext() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		ch := make(chan os.Signal, 1)
+		signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+		defer signal.Stop(ch)
+
+		select {
+		case <-ch:
+			log.Info("Got interrupt, shutting down...")
+		case <-ctx.Done():
+		}
+
+		cancel()
+	}()
+
+	return ctx
+}
+
+func setupLogger(cliCtx *cli.Context) {
+	var (
+		ostream log.Handler
+		glogger *log.GlogHandler
+	)
+
+	usecolor := (isatty.IsTerminal(os.Stderr.Fd()) || isatty.IsCygwinTerminal(os.Stderr.Fd())) && os.Getenv("TERM") != "dumb"
+	output := io.Writer(os.Stderr)
+
+	if usecolor {
+		output = colorable.NewColorableStderr()
+	}
+
+	ostream = log.StreamHandler(output, log.TerminalFormat(usecolor))
+	glogger = log.NewGlogHandler(ostream)
+	log.Root().SetHandler(glogger)
+	glogger.Verbosity(log.Lvl(5))
+}

--- a/cmd/aasim/p2p.go
+++ b/cmd/aasim/p2p.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/ledgerwatch/turbo-geth/crypto"
+	"github.com/ledgerwatch/turbo-geth/eth"
+	"github.com/ledgerwatch/turbo-geth/log"
+	"github.com/ledgerwatch/turbo-geth/p2p"
+	"github.com/ledgerwatch/turbo-geth/p2p/enode"
+)
+
+func makeP2PServer(ctx context.Context, sp *SimulatorProtocol, protocols []string) *p2p.Server {
+	serverKey, err := crypto.GenerateKey()
+	if err != nil {
+		panic(fmt.Sprintf("Failed to generate server key: %v", err))
+	}
+
+	p2pConfig := p2p.Config{
+		PrivateKey: serverKey,
+		Name:       "geth tester",
+		Logger:     log.New(),
+		MaxPeers:   1,
+		Protocols: []p2p.Protocol{
+			{
+				Name:    eth.DebugName,
+				Version: eth.DebugVersions[0],
+				Length:  eth.DebugLengths[eth.DebugVersions[0]],
+				Run: func(peer *p2p.Peer, rw p2p.MsgReadWriter) error {
+					return sp.debugProtocolRun(ctx, peer, rw)
+				},
+			},
+		},
+	}
+
+	return &p2p.Server{Config: p2pConfig}
+}
+
+func getTargetAddr() (*enode.Node, error) {
+	addr, err := ioutil.ReadFile(p2p.EnodeAddressFileName)
+	if err != nil {
+		return nil, err
+	}
+
+	nodeToConnect, err := enode.ParseV4(string(addr))
+	if err != nil {
+		return nil, fmt.Errorf("could not parse the node info: %w", err)
+	}
+
+	log.Info("Parsed node: %s, IP: %s\n", nodeToConnect, nodeToConnect.IP())
+
+	return nodeToConnect, nil
+}

--- a/cmd/aasim/p2p.go
+++ b/cmd/aasim/p2p.go
@@ -23,16 +23,29 @@ func makeP2PServer(ctx context.Context, sp *SimulatorProtocol, protocols []strin
 		Name:       "geth tester",
 		Logger:     log.New(),
 		MaxPeers:   1,
-		Protocols: []p2p.Protocol{
-			{
-				Name:    eth.DebugName,
-				Version: eth.DebugVersions[0],
-				Length:  eth.DebugLengths[eth.DebugVersions[0]],
-				Run: func(peer *p2p.Peer, rw p2p.MsgReadWriter) error {
-					return sp.debugProtocolRun(ctx, peer, rw)
-				},
+	}
+
+	pMap := map[string]p2p.Protocol{
+		eth.ProtocolName: {
+			Name:    eth.ProtocolName,
+			Version: eth.ProtocolVersions[0],
+			Length:  eth.ProtocolLengths[eth.ProtocolVersions[0]],
+			Run: func(peer *p2p.Peer, rw p2p.MsgReadWriter) error {
+				return sp.protocolRun(ctx, peer, rw)
 			},
 		},
+		eth.DebugName: {
+			Name:    eth.DebugName,
+			Version: eth.DebugVersions[0],
+			Length:  eth.DebugLengths[eth.DebugVersions[0]],
+			Run: func(peer *p2p.Peer, rw p2p.MsgReadWriter) error {
+				return sp.debugProtocolRun(ctx, peer, rw)
+			},
+		},
+	}
+
+	for _, protocolName := range protocols {
+		p2pConfig.Protocols = append(p2pConfig.Protocols, pMap[protocolName])
 	}
 
 	return &p2p.Server{Config: p2pConfig}
@@ -52,4 +65,58 @@ func getTargetAddr() (*enode.Node, error) {
 	log.Info("Parsed node: %s, IP: %s\n", nodeToConnect, nodeToConnect.IP())
 
 	return nodeToConnect, nil
+}
+
+func syncHandshake(sp *SimulatorProtocol, rw p2p.MsgReadWriter) error {
+	err := p2p.Send(rw, eth.StatusMsg, &eth.StatusData{
+		ProtocolVersion: sp.protocolVersion,
+		NetworkID:       sp.networkID,
+		TD:              sp.feeder.TotalDifficulty(),
+		Head:            sp.feeder.Head().Hash(),
+		Genesis:         sp.genesis,
+		ForkID:          sp.feeder.ForkID(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to send status message to peer: %w", err)
+	}
+
+	return nil
+}
+
+func readStatus(rw p2p.MsgReadWriter, status *eth.StatusData, sp *SimulatorProtocol) error {
+	msg, err := rw.ReadMsg()
+	if err != nil {
+		return err
+	}
+
+	if msg.Code != eth.StatusMsg {
+		return fmt.Errorf("first msg has code %x (!= %x)", msg.Code, eth.StatusMsg)
+	}
+
+	if msg.Size > eth.ProtocolMaxMsgSize {
+		return fmt.Errorf("%v > %v", msg.Size, eth.ProtocolMaxMsgSize)
+	}
+
+	// Decode the handshake and make sure everything matches
+	if err := msg.Decode(&status); err != nil {
+		return fmt.Errorf("msg %v: %v", msg, err)
+	}
+
+	if status.NetworkID != sp.networkID {
+		return fmt.Errorf("%d (!= %d)", status.NetworkID, sp.networkID)
+	}
+
+	if status.ProtocolVersion != sp.protocolVersion {
+		return fmt.Errorf("%d (!= %d)", status.ProtocolVersion, sp.protocolVersion)
+	}
+
+	if status.Genesis != sp.genesis {
+		return fmt.Errorf("%x (!= %x)", status.Genesis, genesis)
+	}
+
+	// if err := forkFilter(status.ForkID); err != nil {
+	//         return errResp(ErrForkIDRejected, "%v", err)
+	// }
+
+	return nil
 }

--- a/cmd/aasim/protocol.go
+++ b/cmd/aasim/protocol.go
@@ -4,21 +4,93 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 
 	"github.com/ledgerwatch/turbo-geth/common"
+	"github.com/ledgerwatch/turbo-geth/core/types"
 	"github.com/ledgerwatch/turbo-geth/eth"
 	"github.com/ledgerwatch/turbo-geth/log"
 	"github.com/ledgerwatch/turbo-geth/p2p"
+	"github.com/ledgerwatch/turbo-geth/rlp"
 )
 
 type SimulatorProtocol struct {
-	protocolVersion  uint32
-	networkId        uint64
-	genesisBlockHash common.Hash
+	protocolVersion uint32
+	networkID       uint64
+	genesis         common.Hash
+	feeder          BlockFeeder
+
+	// Bitmap to remember which blocks (or just header if the blocks are empty) have been sent already
+	blockMarkers []uint64
+}
+
+// Return true if the block has already been marked. If the block has not been marked, returns false and marks it
+func (sp *SimulatorProtocol) markBlockSent(blockNumber uint) bool {
+	lengthNeeded := (blockNumber+63)/64 + 1
+
+	if lengthNeeded > uint(len(sp.blockMarkers)) {
+		sp.blockMarkers = append(sp.blockMarkers, make([]uint64, lengthNeeded-uint(len(sp.blockMarkers)))...)
+	}
+
+	bitMask := (uint64(1) << (blockNumber & 63))
+	result := (sp.blockMarkers[blockNumber/64] & bitMask) != 0
+	sp.blockMarkers[blockNumber/64] |= bitMask
+
+	return result
 }
 
 func NewSimulatorProtocol() *SimulatorProtocol {
 	return &SimulatorProtocol{}
+}
+
+func (sp *SimulatorProtocol) protocolRun(ctx context.Context, p *p2p.Peer, rw p2p.MsgReadWriter) error {
+	log.Info("Ethereum peer connected", "peer", p.Name())
+	log.Debug("Protocol version", "version", sp.protocolVersion)
+
+	err := syncHandshake(sp, rw)
+	if err != nil {
+		return fmt.Errorf("Handshake failed: %s", err)
+	}
+
+	sentBlocks := 0
+	emptyBlocks := 0
+	signaledHead := false
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		// Read the next message
+		msg, err := rw.ReadMsg()
+		if err != nil {
+			return fmt.Errorf("failed to receive message from peer: %w", err)
+		}
+
+		switch {
+		case msg.Code == eth.GetBlockHeadersMsg:
+			if emptyBlocks, err = sp.handleGetBlockHeaderMsg(msg, rw, sp.feeder, emptyBlocks); err != nil {
+				return err
+			}
+		case msg.Code == eth.GetBlockBodiesMsg:
+			if sentBlocks, err = sp.handleGetBlockBodiesMsg(msg, rw, sp.feeder, sentBlocks); err != nil {
+				return err
+			}
+		case msg.Code == eth.NewBlockHashesMsg:
+			if signaledHead, err = sp.handleNewBlockHashesMsg(msg, rw); err != nil {
+				return err
+			}
+		default:
+			log.Trace("Next message", "msg", msg)
+		}
+
+		if signaledHead {
+			break
+		}
+	}
+
+	return nil
 }
 
 func (sp *SimulatorProtocol) debugProtocolRun(ctx context.Context, peer *p2p.Peer, rw p2p.MsgReadWriter) error {
@@ -35,4 +107,154 @@ func (sp *SimulatorProtocol) debugProtocolRun(ctx context.Context, peer *p2p.Pee
 	log.Info("eth set custom genesis.config")
 
 	return nil
+}
+
+// hashOrNumber is a combined field for specifying an origin block.
+type hashOrNumber struct {
+	Hash   common.Hash // Block hash from which to retrieve headers (excludes Number)
+	Number uint64      // Block hash from which to retrieve headers (excludes Hash)
+}
+
+// getBlockHeadersData represents a block header query.
+type getBlockHeadersData struct {
+	Origin  hashOrNumber // Block from which to retrieve headers
+	Amount  uint64       // Maximum number of headers to retrieve
+	Skip    uint64       // Blocks to skip between consecutive headers
+	Reverse bool         // Query direction (false = rising towards latest, true = falling towards genesis)
+}
+
+// newBlockHashesData is the network packet for the block announcements.
+type newBlockHashesData []struct {
+	Hash   common.Hash // Hash of one particular block being announced
+	Number uint64      // Number of one particular block being announced
+}
+
+// EncodeRLP is a specialized encoder for hashOrNumber to encode only one of the
+// two contained union fields.
+func (hn *hashOrNumber) EncodeRLP(w io.Writer) error {
+	if hn.Hash == (common.Hash{}) {
+		return rlp.Encode(w, hn.Number)
+	}
+	if hn.Number != 0 {
+		return fmt.Errorf("both origin hash (%x) and number (%d) provided", hn.Hash, hn.Number)
+	}
+	return rlp.Encode(w, hn.Hash)
+}
+
+// DecodeRLP is a specialized decoder for hashOrNumber to decode the contents
+// into either a block hash or a block number.
+func (hn *hashOrNumber) DecodeRLP(s *rlp.Stream) error {
+	_, size, _ := s.Kind()
+	origin, err := s.Raw()
+	if err == nil {
+		switch {
+		case size == 32:
+			err = rlp.DecodeBytes(origin, &hn.Hash)
+		case size <= 8:
+			err = rlp.DecodeBytes(origin, &hn.Number)
+		default:
+			err = fmt.Errorf("invalid input size %d for origin", size)
+		}
+	}
+	return err
+}
+
+func (sp *SimulatorProtocol) handleGetBlockHeaderMsg(msg p2p.Msg, rw p2p.MsgReadWriter, blockFeeder BlockFeeder, emptyBlocks int) (int, error) {
+	newEmptyBlocks := emptyBlocks
+
+	var query getBlockHeadersData
+	if err := msg.Decode(&query); err != nil {
+		return newEmptyBlocks, fmt.Errorf("failed to decode msg %v: %w", msg, err)
+	}
+
+	log.Trace("GetBlockHeadersMsg", "query", query)
+	headers := []*types.Header{}
+	if query.Origin.Hash == (common.Hash{}) && !query.Reverse {
+		number := query.Origin.Number
+		for i := 0; i < int(query.Amount); i++ {
+			if header := blockFeeder.GetHeaderByNumber(number); header != nil {
+				headers = append(headers, header)
+				if header.TxHash == types.EmptyRootHash {
+					if !sp.markBlockSent(uint(number)) {
+						newEmptyBlocks++
+					}
+				}
+			} else {
+				//fmt.Printf("Could not find header with number %d\n", number)
+			}
+			number += query.Skip + 1
+		}
+	}
+	if query.Origin.Hash != (common.Hash{}) && query.Amount == 1 && query.Skip == 0 && !query.Reverse {
+		if header := blockFeeder.GetHeaderByHash(query.Origin.Hash); header != nil {
+			log.Trace("Going to send header", "number", header.Number.Uint64())
+			headers = append(headers, header)
+		}
+	}
+	if err := p2p.Send(rw, eth.BlockHeadersMsg, headers); err != nil {
+		return newEmptyBlocks, fmt.Errorf("failed to send headers: %w", err)
+	}
+	log.Info(fmt.Sprintf("Sent %d headers, empty blocks so far %d", len(headers), newEmptyBlocks))
+	return newEmptyBlocks, nil
+}
+
+func (sp *SimulatorProtocol) handleGetBlockBodiesMsg(msg p2p.Msg, rw p2p.MsgReadWriter, blockFeeder BlockFeeder, sentBlocks int) (int, error) {
+	newSentBlocks := sentBlocks
+	msgStream := rlp.NewStream(msg.Payload, uint64(msg.Size))
+	log.Trace("GetBlockBodiesMsg with size", "size", msg.Size)
+	if _, err := msgStream.List(); err != nil {
+		return newSentBlocks, err
+	}
+	// Gather blocks until the fetch or network limits is reached
+	var (
+		hash   common.Hash
+		bodies []rlp.RawValue
+	)
+	for {
+		// Retrieve the hash of the next block
+		if err := msgStream.Decode(&hash); err == rlp.EOL {
+			break
+		} else if err != nil {
+			return newSentBlocks, fmt.Errorf("failed to decode msg %v: %w", msg, err)
+		}
+		// Retrieve the requested block body, stopping if enough was found
+		if block, err := blockFeeder.GetBlockByHash(hash); err != nil {
+			return newSentBlocks, fmt.Errorf("failed to read block %w", err)
+		} else if block != nil {
+			if !sp.markBlockSent(uint(block.NumberU64())) {
+				newSentBlocks++
+			}
+
+			body := block.Body()
+			// Need to transform because our blocks also contain list of tx senders
+			smallBody := types.SmallBody{Transactions: body.Transactions, Uncles: body.Uncles}
+			data, err := rlp.EncodeToBytes(smallBody)
+			if err != nil {
+				return newSentBlocks, fmt.Errorf("failed to encode body: %w", err)
+			}
+			bodies = append(bodies, data)
+		}
+	}
+	if err := p2p.Send(rw, eth.BlockBodiesMsg, bodies); err != nil {
+		return newSentBlocks, err
+	}
+	log.Info("Sending bodies", "progress", newSentBlocks)
+
+	return newSentBlocks, nil
+}
+
+func (sp *SimulatorProtocol) handleNewBlockHashesMsg(msg p2p.Msg, rw p2p.MsgReadWriter) (bool, error) {
+	var blockHashMsg newBlockHashesData
+	if err := msg.Decode(&blockHashMsg); err != nil {
+		return false, fmt.Errorf("failed to decode msg %v: %w", msg, err)
+	}
+	log.Trace("NewBlockHashesMsg", "query", blockHashMsg)
+	signaledHead := false
+	for _, bh := range blockHashMsg {
+		if bh.Number == sp.feeder.Head().NumberU64() {
+			signaledHead = true
+			break
+		}
+	}
+	return signaledHead, nil
 }

--- a/cmd/aasim/protocol.go
+++ b/cmd/aasim/protocol.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ledgerwatch/turbo-geth/common"
+	"github.com/ledgerwatch/turbo-geth/eth"
+	"github.com/ledgerwatch/turbo-geth/log"
+	"github.com/ledgerwatch/turbo-geth/p2p"
+)
+
+type SimulatorProtocol struct {
+	protocolVersion  uint32
+	networkId        uint64
+	genesisBlockHash common.Hash
+}
+
+func NewSimulatorProtocol() *SimulatorProtocol {
+	return &SimulatorProtocol{}
+}
+
+func (sp *SimulatorProtocol) debugProtocolRun(ctx context.Context, peer *p2p.Peer, rw p2p.MsgReadWriter) error {
+	block, err := json.Marshal(genesis())
+	if err != nil {
+		return err
+	}
+
+	err = p2p.Send(rw, eth.DebugSetGenesisMsg, block)
+	if err != nil {
+		return fmt.Errorf("failed to send DebugSetGenesisMsg message to peer: %w", err)
+	}
+
+	log.Info("eth set custom genesis.config")
+
+	return nil
+}

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -567,7 +567,7 @@ func (p *peer) Handshake(network uint64, td *big.Int, head common.Hash, genesis 
 
 	var (
 		status63 statusData63 // safe to read after two values have been received from errc
-		status   statusData   // safe to read after two values have been received from errc
+		status   StatusData   // safe to read after two values have been received from errc
 	)
 	go func() {
 		switch {
@@ -580,7 +580,7 @@ func (p *peer) Handshake(network uint64, td *big.Int, head common.Hash, genesis 
 				GenesisBlock:    genesis,
 			})
 		case p.version >= eth64:
-			errc <- p2p.Send(p.rw, StatusMsg, &statusData{
+			errc <- p2p.Send(p.rw, StatusMsg, &StatusData{
 				ProtocolVersion: uint32(p.version),
 				NetworkID:       network,
 				TD:              td,
@@ -653,7 +653,7 @@ func (p *peer) readStatusLegacy(network uint64, status *statusData63, genesis co
 	return nil
 }
 
-func (p *peer) readStatus(network uint64, status *statusData, genesis common.Hash, forkFilter forkid.Filter) error {
+func (p *peer) readStatus(network uint64, status *StatusData, genesis common.Hash, forkFilter forkid.Filter) error {
 	msg, err := p.rw.ReadMsg()
 	if err != nil {
 		return err

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -136,7 +136,7 @@ type statusData63 struct {
 }
 
 // statusData is the network packet for the status message for eth/64 and later.
-type statusData struct {
+type StatusData struct {
 	ProtocolVersion uint32
 	NetworkID       uint64
 	TD              *big.Int


### PR DESCRIPTION
## Metrics to Measure
* single tx validation time
* total validation time (including replacing with new transactions)
* execution time
* gas payment
* propagation delay

## Strategies
1. Transactions which invalidates an existing transaction
    * locally
    * shared by peers
    * from new blocks
3. Send transactions which builds on an existing transaction
    * locally
    * shared by peers
5. Combinations of 1 & 2

## Design

There are two main areas of work that must be completed:
* metrics tracking inside turbo-geth
* simulator that connects to turbo-geth

[0]: https://github.com/ethereum/go-ethereum/wiki/Metrics-and-Monitoring

### Additions to Metrics Tracking

TODO (mostly out-of-scope for now)

### Simulator

New transactions can reach a node in one of two ways:
* from a devp2p peer
* locally via RPC

In order to properly simulate edge cases in AA validation, the simulator should propagate transactions using both means to the node. The `main loop` can be thought of as the brain of the simulation. It should dictate when new blocks will be created(RD: clarification Q: why/how is simulating dictating when new block is created? Shouldn't that be in turbo-get test client or tesnet automatically from mempool? MG: The model I had in my brain was that simulator would be the overall orchestrator and would manage the "testnet" and would decide what transactions to seed to the network and when/how to attack it), peer with the turbo-geth client, call the transaction generator to generate a new transaction -- using one of the strategies above, and relay the transaction to the simulator using one of its fabricated peers.

![](https://i.imgur.com/HhRfl6q.png)